### PR TITLE
Fix video link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ luci_tutorials
 
 <p>These "Tutorials" are simply notes I used during a casual training I did on LuCI. </p>
 
-[You can find the training video here](https://www.youtube.com/edit?o=U&video_id=hSHXySh6lrI)
+[You can find the training video here](https://www.youtube.com/watch?v=hSHXySh6lrI)
 
 <p>The LuCI web interface is slowly being moved to a JSON-RPC structure to reduce the ammount of on-node processing. The notes contained here that are focused on the CBI structure will eventually be supported by work about how to build the on-node hooks that allow browser-plugins and sites to communicate remotely with a LuCI enabled openWRT node.</p>
 


### PR DESCRIPTION
Training video URL was author-only edit link, now publicly-viewable watch link.